### PR TITLE
Fixed a bug in Reynolds number calculation

### DIFF
--- a/OpenHydraulics/Basic/VariableRestriction.mo
+++ b/OpenHydraulics/Basic/VariableRestriction.mo
@@ -48,7 +48,7 @@ model VariableRestriction "Flow loss due to controllable restriction"
     "Turbulent flow if |m_flow| >= m_flow_small"
     annotation(Dialog(tab="Advanced", enable=not use_Re and not from_dp));
 
-  SI.ReynoldsNumber Re = ReynoldsNumber_m_flow(
+  SI.ReynoldsNumber Re = BaseClasses.ReynoldsNumber_m_flow(
         port_a.m_flow,
         (oil.dynamicViscosity(p_a) + oil.dynamicViscosity(p_b))/2,
         data.D_Re) if use_Re "Reynolds number at diameter D_Re";

--- a/OpenHydraulics/Basic/VariableRestrictionSeriesValve.mo
+++ b/OpenHydraulics/Basic/VariableRestrictionSeriesValve.mo
@@ -44,7 +44,7 @@ model VariableRestrictionSeriesValve
 
   extends BaseClasses.RestrictionInterface;
 
-  SI.ReynoldsNumber Re = ReynoldsNumber_m_flow(
+  SI.ReynoldsNumber Re = BaseClasses.ReynoldsNumber_m_flow(
         port_a.m_flow,
         (oil.dynamicViscosity(p_a) + oil.dynamicViscosity(p_b))/2,
         data.D_Re) if use_Re "Reynolds number at diameter D_Re";


### PR DESCRIPTION
The flag `use_Re` calls an unknown function if it is set to `true`.  This fixes it by qualifying
the function name so it can find the Modelica function.  Otherwise, Dymola falls back to
assuming it is an external C function (which doesn't exist).
