### PR TITLE
Bugs in GenericOil, real-equality-with-0

### DIFF
--- a/OpenHydraulics/Basic/FluidPower2MechTrans.mo
+++ b/OpenHydraulics/Basic/FluidPower2MechTrans.mo
@@ -46,7 +46,11 @@ algorithm
   assert(V>0,"Volume in fluid chamber is negative or zero.\n"+
               "Increase the residualVolume or the stopStiffness");
   assert(p_vol<maxPressure or s_rel<0,"Maxiumum pressure in chamber has been exceeded");
-  assert(not empty, "CylinderChamber has reached end of travel.\n\tThis could cause erratic behavior of the simulation.\n\t(time = "+String(time)+")", AssertionLevel.warning);
+  when empty then
+    Modelica.Utilities.Streams.print("\nWARNING: CylinderChamber has reached end of travel.");
+    Modelica.Utilities.Streams.print("         This could cause erratic behavior of the simulation.");
+    Modelica.Utilities.Streams.print("         (time = "+String(time)+")");
+  end when;
 
 equation
   // medium equations

--- a/OpenHydraulics/Components/Cylinders/DoubleActingCylinder.mo
+++ b/OpenHydraulics/Components/Cylinders/DoubleActingCylinder.mo
@@ -242,8 +242,16 @@ initial equation
   end if;
 
 equation
-  assert(cushionRod.reliefValve.valvePositionSteadyState<=0, "Cylinder exceeds maximum pressure at the rod end.\n\tThis could just be due to end-of-travel behavior.\n\t(time = "+String(time)+")", AssertionLevel.warning);
-  assert(cushionHead.reliefValve.valvePositionSteadyState<=0, "Cylinder exceeds maximum pressure at the head end.\n\tThis could just be due to end-of-travel behavior.\n\t(time = "+String(time)+")", AssertionLevel.warning);
+  when cushionRod.reliefValve.valvePositionSteadyState>0 then
+    Modelica.Utilities.Streams.print("\nWARNING: Cylinder exceeds maximum pressure at the rod end.");
+    Modelica.Utilities.Streams.print("         This could just be due to end-of-travel behavior.");
+    Modelica.Utilities.Streams.print("         (time = "+String(time)+")");
+  end when;
+  when cushionHead.reliefValve.valvePositionSteadyState>0 then
+    Modelica.Utilities.Streams.print("\nWARNING: Cylinder exceeds maximum pressure at the head end.");
+    Modelica.Utilities.Streams.print("         This could just be due to end-of-travel behavior.");
+    Modelica.Utilities.Streams.print("         (time = "+String(time)+")");
+  end when;
 
   connect(cylinderChamberHead.flange_b, piston.flange_a)
     annotation (Line(points={{-30,0},{-10,0}}, color={0,127,0}));


### PR DESCRIPTION
GenericOil references a type, Density, and a variable, T, neither of which is defined. Density is presumably SI.Density, T should be Toperating as this is done in dynamicViscosity()? (Though I'm not sure if a function should access a parameter in the enclosing scope).

ConstVolumeSource contains an if-equation that compares a Real parameter q with 0, however since the right-hand-side of the resulting equation is multiplied by q the same effect can be achieved by forcing q to be evaluated.

Other change (removal of Streams.print() in favor of assert()) in previous pull-request has been reverted
